### PR TITLE
Handle pull_request_target

### DIFF
--- a/lib/action.rb
+++ b/lib/action.rb
@@ -13,7 +13,7 @@ begin
   config = GithubApiConfig.new
   puts "Event: #{config.event_name} called"
   case config.event_name
-  when 'pull_request'
+  when 'pull_request', 'pull_request_target'
     if config.event_payload['action'] == 'opened' || config.event_payload['action'] == 'synchronize'
       puts 'Pull request is opened or synchronized'
       puts '============================================='


### PR DESCRIPTION
We need to include pull_request_target as an action.

The reason for the switch is this allows actions to run for Dependabot.