### PR TITLE
Try faraday-retry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ group :development, :test do
   gem 'vcr'
   gem 'webmock'
 end
+
+gem "faraday-retry", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -91,6 +93,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake-ruby
   faraday
+  faraday-retry (~> 2.0)
   octokit
   rspec
   simplycop


### PR DESCRIPTION
The Octokit library outputs debug that it will automatically retry if `faraday-retry` is available.

We have a timeout earlier this week, so adding to see if we get any timeouts in future.

https://simplybusiness.airbrake.io/projects/258121/groups/3422227754895317301?tab=overview