### PR TITLE
Refactor deploy status messages for clarity

### DIFF
--- a/lib/functionality/issue_deploy_check.rb
+++ b/lib/functionality/issue_deploy_check.rb
@@ -16,11 +16,11 @@ class IssueDeployCheck < BaseDeployCheck
     case config.event_payload['action']
     when 'labeled'
       github_summary_message += "### :boom: Deploys are blocked :boom:\n"
-      create_status_for_all_prs(config, 'failure', github_summary_message)
+      create_status_for_all_prs(config, 'failure', 'Deploys are blocked')
     when 'closed'
       if SimplyIssue.get_all_issues(config, 'issues', 'block deploys').empty?
         github_summary_message += "### :sparkles: You are free to deploy :sparkles:\n"
-        create_status_for_all_prs(config, 'success', github_summary_message)
+        create_status_for_all_prs(config, 'success', 'You are free to deploy')
       end
     end
   end

--- a/lib/functionality/issue_deploy_check.rb
+++ b/lib/functionality/issue_deploy_check.rb
@@ -16,22 +16,22 @@ class IssueDeployCheck < BaseDeployCheck
     case config.event_payload['action']
     when 'labeled'
       github_summary_message += "### :boom: Deploys are blocked :boom:\n"
-      create_status_for_all_prs(config, 'failure', 'Deploys are blocked')
+      create_status_for_all_prs(config, 'failure', 'Deploys are blocked', github_summary_message)
     when 'closed'
       if SimplyIssue.get_all_issues(config, 'issues', 'block deploys').empty?
         github_summary_message += "### :sparkles: You are free to deploy :sparkles:\n"
-        create_status_for_all_prs(config, 'success', 'You are free to deploy')
+        create_status_for_all_prs(config, 'success', 'You are free to deploy', github_summary_message)
       end
     end
   end
 
-  def self.create_status_for_all_prs(config, status, message)
+  def self.create_status_for_all_prs(config, status, status_message, message)
     config.client.auto_paginate = true
     all_pull_requests = SimplyIssue.get_all_issues(config, 'pull_request')
     all_pull_requests.each do |pr|
       result = config.client.create_status(
         config.app_repo, pr['head']['sha'], status,
-        description: message,
+        description: status_message,
         context: context_name,
         target_url: config.event_payload['html_url']
       )


### PR DESCRIPTION
This pull request includes changes to the `lib/functionality/issue_deploy_check.rb` file to simplify the status messages passed to the `create_status_for_all_prs` method. The most important change is the modification of the messages to be more concise.

Simplification of status messages:

* [`lib/functionality/issue_deploy_check.rb`](diffhunk://#diff-6d2b3f0f3d97fb58ffca554217e80dfe29b051fe76054c87499139c5dc08239bL19-R23): Modified the `check_current_issue` method to pass concise status messages ('Deploys are blocked' and 'You are free to deploy') to the `create_status_for_all_prs` method.